### PR TITLE
Added :center option to oval

### DIFF
--- a/lib/shoes/app.rb
+++ b/lib/shoes/app.rb
@@ -318,6 +318,10 @@ class Shoes
       args = basic_attributes args
       args[:width].zero? ? (args[:width] = args[:radius] * 2) : (args[:radius] = args[:width]/2.0)
       args[:height] = args[:width] if args[:height].zero?
+      if args[:center]
+        args[:left] -= args[:width] / 2
+        args[:top] -= args[:width] / 2
+      end
       args[:strokewidth] = ( args[:strokewidth] or strokewidth or 1 )
       args[:nocontrol] = args[:noorder] = true
 

--- a/lib/shoes/basic.rb
+++ b/lib/shoes/basic.rb
@@ -54,11 +54,16 @@ class Shoes
     end
 
     def move3 x, y
+      x, y = center_at(x, y) if @center
       unless @app.cs.isDisposed
         @app.cs.redraw @left, @top, @width, @height, false
         @app.cs.redraw x, y, @width, @height, false
       end
       @left, @top = x, y
+    end
+
+    def center_at x, y
+      [x - (@width / 2), y - (@height / 2)]
     end
 
     def positioning x, y, max


### PR DESCRIPTION
The manual says that the oval method can have a `:center` option, which will make `top` and `left` mark the center of the oval. Red Shoes does this, but purple shoes doesn't. Now it does :)

Here's a sample app that should draw a snowman:

```
Shoes.app do
  oval(200, 100, 40)
  oval(180, 180, 120, 120)
  oval(radius: 100, left: 240, top: 400, center: true)
 end
```

Before:

![before](https://img.skitch.com/20120410-cahtbwi5mdhkfypqxumcjjydjw.medium.jpg)

After:

![after](https://img.skitch.com/20120410-rdq94p2xc1jfck91u6fh556s4t.medium.jpg)
